### PR TITLE
esp32: make 80Mhz default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ platform = espressif32
 monitor_filters = esp32_exception_decoder
 extra_scripts = merge-bin.py
 build_flags = ${arduino_base.build_flags}
-;  -D ESP32_CPU_FREQ=80          ; change it to your need
+  -D ESP32_CPU_FREQ=80          ; 80Mhz for cooler boards and better battery life
 build_src_filter = ${arduino_base.build_src_filter}
 
 [esp32_ota]


### PR DESCRIPTION
for better battery life and cooler devices